### PR TITLE
remove code causing NullReferenceException

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -25,7 +25,7 @@ namespace FoodTweaker
 
         }
 
-        public static GearItem GetGearItemPrefab(string name) => GearItem.LoadGearItemPrefab(name).GetComponent<GearItem>();
+        public static GearItem GetGearItemPrefab(string name) => GearItem.LoadGearItemPrefab(name);
 
         public static void UpdateGearItemPrefab(string name, int calories, int hydration, int vitamin, bool warmingBuff = false)
         {


### PR DESCRIPTION
Since `GearItem.LoadGearItemPrefab(name)` can return null,
it might be better to add a null check in this code.

The return type of `LoadGearItemPrefab(name)` is `GearItem`,
so I’m wondering if there’s a specific reason for using `.GetComponent<GearItem>()` here.

If there’s no particular reason,
it might be better to remove the `GetComponent` call as modified in the PR.

https://store.steampowered.com/app/2091330/The_Long_Dark_Tales_from_the_Far_Territory/
If DLC is not enabled, the DLC prefab (*CookedMeatPtarmigan, BanockAcorn, etc.)
cannot be retrieved, resulting in an error
```
[FoodTweaker] System.NullReferenceException: Object reference not set to an instance of an object.
   at FoodTweaker.Main.GetGearItemPrefab(String name) in C:\Users\romai\source\repos\FoodTweaker\Main.cs:line 28
   at FoodTweaker.Main.UpdateGearItemPrefab(String name, Int32 calories, Int32 hydration, Int32 vitamin, Boolean warmingBuff) in C:\Users\romai\source\repos\FoodTweaker\Main.cs:line 32
   at FoodTweaker.Main.ChangePrefabs() in C:\Users\romai\source\repos\FoodTweaker\Main.cs:line 205
   at FoodTweaker.Main.OnSceneWasInitialized(Int32 buildIndex, String sceneName) in C:\Users\romai\source\repos\FoodTweaker\Main.cs:line 23
   at MelonLoader.MelonEventBase`1.Invoke(Action`1 delegateInvoker) in D:\a\MelonLoader\MelonLoader\MelonLoader\Melons\Events\MelonEvent.cs:line 143
```